### PR TITLE
Ts fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # ESLint
-Linting rules for JavaScript (ESLint)
+Linting rules for JavaScript and TypeScript (ESLint)
 
 ## Use
 - Reference this package and eslint in your packages.json, e.g.:
 ```javascript
 
 "devDependencies": {
-    "eslint": "^3.14.1",
-    "eslint-config-techsmith": "git+ssh://git@github.com/TechSmith/ESLint.git#<latest_version>"
+    "eslint": "^6.30.0",
+    "eslint-config-techsmith": "^2.1.0"
   }
 ```
 
+- Depending on which rule set you use, you may need to install additional plugins to your dependencies. You should get helpful error messages pointing out the needed dependencies when you go to run the linting. 
 - Create an `eslintConfig` entry in your package.json file referencing the TechSmith ESLint rules, e.g.:
 
 ```
@@ -40,12 +41,13 @@ module.exports = {
 };
 ```
 
-- Configure WebStorm to know about your linting rules: https://www.jetbrains.com/help/webstorm/2016.3/eslint.html
+- If you're using VSCode, you should install eslint plugins to get in-IDE linting
+- If you're using webstorm, this may help you integrate these rules into the IDE: https://www.jetbrains.com/help/webstorm/2016.3/eslint.html
 
 ## Integrating into your build
 
 - Run eslint as part of your build to ensure your JavaScript is up to snuff!
-- Add the following to your package.json file
+- As an example, add the following to your package.json file
 
 ```javascript
 "scripts": {
@@ -55,3 +57,12 @@ module.exports = {
 
 - Run the script as a "custom script" build step: `npm run lint` or `yarn lint`
 - Advanced users can consider integrating ESLint into their build via other mechanics (e.g. a WebPack loader or a grunt step)
+
+## Releasing
+
+This is a public npm package. These are the steps for releasing
+
+1) Merge PR / update version number in package.json
+2) npm login
+3) Enter credentials for npm login obtained from the usual place credentials are stored (leaving this deliberately vague since this is a public repo)
+4) npm publish

--- a/common-rules.js
+++ b/common-rules.js
@@ -58,7 +58,7 @@
       'no-useless-concat': error(),
       'no-useless-escape': error(),
       'no-useless-return': error(),
-      'no-void': error(),
+      'no-void': error({allowAsStatement: true}),
       'no-with': error(),
       'radix': error(),
       'vars-on-top': error(),

--- a/common-rules.js
+++ b/common-rules.js
@@ -5,7 +5,10 @@
 
    module.exports = {
       'no-console': error(),
-      'no-extra-parens': error(),
+      'no-extra-parens': error('all', {
+         nestedBinaryExpressions: false,
+         ignoreJSX: 'all'
+      }),
       'no-unsafe-negation': error(),
       'curly': error('all'),
       'dot-location': error('property'),

--- a/es6-rules.js
+++ b/es6-rules.js
@@ -7,7 +7,6 @@
       'arrow-parens': error('as-needed'),
       'arrow-spacing': error(),
       'generator-star-spacing': error(),
-      'no-confusing-arrow': error(),
       'no-duplicate-imports': error(),
       'no-useless-computed-key': error(),
       'no-useless-constructor': error(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techsmith",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "peerDependencies": {
     "eslint": ">=6.30.0"
   }

--- a/ts.js
+++ b/ts.js
@@ -128,6 +128,7 @@
             "allowConciseArrowFunctionExpressionsStartingWithVoid": false
          }
       ],
+      '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}],
       'arrow-body-style': [
          'error', 
          'as-needed'

--- a/ts.js
+++ b/ts.js
@@ -72,6 +72,7 @@
       ],
       '@typescript-eslint/member-ordering': 'error',
       '@typescript-eslint/naming-convention': 'off',
+      'no-empty-function': 'off',
       '@typescript-eslint/no-empty-function': 'error',
       '@typescript-eslint/no-empty-interface': 'error',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/ts.js
+++ b/ts.js
@@ -86,6 +86,15 @@
             'hoist': 'all'
          }
       ],
+      'no-extra-parens': 'off',
+      '@typescript-eslint/no-extra-parens': [
+         'error',
+         'all',
+         {
+            'nestedBinaryExpressions': false,
+            'ignoreJSX': 'all' 
+         }
+      ],
       '@typescript-eslint/no-unused-expressions': [
          'error',
          {


### PR DESCRIPTION
A few things based on learnings from implementing these rules in Audiate. See commits for details. The one bit of opinion is changing `@typescript-eslint/no-inferrable-types` to allow arguments as inferred types. This allows you to do something like `const add = (b: number, a: number = 1) => a + b;`. Previously that would yell at you because you're not allowed to type `a` because its type can be inferred, but I personally like giving it a type despite the inference. Maybe that's dumb, and I'd take push back, but it looks weird to my eyes to type some arguments and not others (and the fact that there is an option in the rule to enable this behavior suggests that it's a legit thing to want to do).

The other two rule changes are pretty necessary, I think.