### PR TITLE
Rule fixups

### DIFF
--- a/common-rules.js
+++ b/common-rules.js
@@ -115,6 +115,34 @@
       'space-in-parens': error(),
       'space-infix-ops': error(),
       'space-unary-ops': error(),
-      'unicode-bom': error()
+      'unicode-bom': error(),
+      'no-invalid-this': 'error',
+      'no-caller': 'error',
+      'id-match': 'error',
+      'id-denylist': [
+         'error',
+         'any',
+         'Number',
+         'number',
+         'String',
+         'string',
+         'Boolean',
+         'boolean',
+         'Undefined',
+         'undefined'
+      ],
+      'id-blacklist': [ // deprecated
+         'error',
+         'any',
+         'Number',
+         'number',
+         'String',
+         'string',
+         'Boolean',
+         'boolean',
+         'Undefined',
+         'undefined'
+      ],
+      'guard-for-in': 'error',
    };
 }());

--- a/common-rules.js
+++ b/common-rules.js
@@ -107,7 +107,11 @@
       'quote-props': error('as-needed'),
       'semi-spacing': error(),
       'space-before-blocks': error(),
-      'space-before-function-paren': error('never'),
+      'space-before-function-paren': error({
+         'anonymous': 'never',
+         'asyncArrow': 'always',
+         'named': 'never'
+      }),
       'space-in-parens': error(),
       'space-infix-ops': error(),
       'space-unary-ops': error(),

--- a/common-rules.js
+++ b/common-rules.js
@@ -144,5 +144,15 @@
          'undefined'
       ],
       'guard-for-in': 'error',
+      'spaced-comment': [
+         'error',
+         'always',
+         {
+            'markers': [
+               '/'
+            ]
+         }
+      ],
+      'no-underscore-dangle': 'error',
    };
 }());

--- a/es6-rules.js
+++ b/es6-rules.js
@@ -21,6 +21,25 @@
       'rest-spread-spacing': error(),
       'template-curly-spacing': error(),
       'yield-star-spacing': error(),
-      'jsx-quotes': error()
+      'jsx-quotes': error(),
+      'spaced-comment': [
+         'error',
+         'always',
+         {
+            'markers': [
+               '/'
+            ]
+         }
+      ],
+      'no-underscore-dangle': 'error',
+      'prefer-arrow/prefer-arrow-functions': 'error',
+      'max-classes-per-file': [
+         'error',
+         1
+      ],
+      'arrow-body-style': [
+         'error',
+         'as-needed'
+      ],
    };
 }());

--- a/es6-rules.js
+++ b/es6-rules.js
@@ -22,16 +22,6 @@
       'template-curly-spacing': error(),
       'yield-star-spacing': error(),
       'jsx-quotes': error(),
-      'spaced-comment': [
-         'error',
-         'always',
-         {
-            'markers': [
-               '/'
-            ]
-         }
-      ],
-      'no-underscore-dangle': 'error',
       'prefer-arrow/prefer-arrow-functions': 'error',
       'max-classes-per-file': [
          'error',

--- a/es6.js
+++ b/es6.js
@@ -15,6 +15,9 @@
             jsx: true
          }
       },
+      plugins: [
+         'eslint-plugin-prefer-arrow',
+      ],
       rules: Object.assign({}, commonRules, es6Rules)
    };
 }());

--- a/ts.js
+++ b/ts.js
@@ -137,55 +137,7 @@
             "allowConciseArrowFunctionExpressionsStartingWithVoid": false
          }
       ],
-      '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}],
-      'arrow-body-style': [
-         'error', 
-         'as-needed'
-      ],
-      'complexity': 'off',
-      'constructor-super': 'error',
-      'curly': 'error',
-      'guard-for-in': 'error',
-      'id-blacklist': [
-         'error',
-         'any',
-         'Number',
-         'number',
-         'String',
-         'string',
-         'Boolean',
-         'boolean',
-         'Undefined',
-         'undefined'
-      ],
-      'id-match': 'error',
-      'max-classes-per-file': [
-         'error',
-         1
-      ],
-      'max-len': 'off',
-      'no-caller': 'error',
-      'no-cond-assign': 'error',
-      'no-debugger': 'error',
-      'no-empty': 'error',
-      'no-fallthrough': 'off',
-      'no-invalid-this': 'off',
-      'no-underscore-dangle': 'error',
-      'no-unsafe-finally': 'error',
-      'no-unused-labels': 'error',
-      'prefer-arrow/prefer-arrow-functions': 'error',
-      'spaced-comment': [
-         'error',
-         'always',
-         {
-            'markers': [
-               '/'
-            ]
-         }
-      ],
-      'use-isnan': 'error',
-      'valid-typeof': 'off',
-      'linebreak-style': 'off'
+      '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}]
    };
 
    module.exports = {
@@ -195,7 +147,8 @@
       },
       extends: [
          'plugin:@typescript-eslint/recommended',
-         'plugin:@typescript-eslint/recommended-requiring-type-checking'
+         'plugin:@typescript-eslint/recommended-requiring-type-checking',
+         'eslint:recommended'
       ],
       parser: '@typescript-eslint/parser',
       parserOptions: {

--- a/ts.js
+++ b/ts.js
@@ -6,7 +6,7 @@
       '@typescript-eslint/array-type': [
          'error',
          {
-            'default': 'array-simple'
+            'default': 'array'
          }
       ],
       '@typescript-eslint/ban-types': [

--- a/ts.js
+++ b/ts.js
@@ -174,14 +174,6 @@
       'no-unsafe-finally': 'error',
       'no-unused-labels': 'error',
       'prefer-arrow/prefer-arrow-functions': 'error',
-      'space-before-function-paren': [
-         'error',
-         {
-            'anonymous': 'never',
-            'asyncArrow': 'always',
-            'named': 'never'
-         }
-      ],
       'spaced-comment': [
          'error',
          'always',

--- a/ts.js
+++ b/ts.js
@@ -2,7 +2,6 @@
    var commonRules = require('./common-rules');
    var es6Rules = require('./es6-rules');
    var typescriptRules = {
-      '@typescript-eslint/adjacent-overload-signatures': 'error',
       '@typescript-eslint/array-type': [
          'error',
          {
@@ -72,12 +71,7 @@
       ],
       '@typescript-eslint/member-ordering': 'error',
       '@typescript-eslint/naming-convention': 'off',
-      'no-empty-function': 'off',
-      '@typescript-eslint/no-empty-function': 'error',
-      '@typescript-eslint/no-empty-interface': 'error',
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-misused-new': 'error',
-      '@typescript-eslint/no-namespace': 'error',
       '@typescript-eslint/no-parameter-properties': 'off',
       'no-shadow': 'off',
       '@typescript-eslint/no-shadow': [
@@ -107,7 +101,6 @@
       '@typescript-eslint/no-var-requires': 'error',
       '@typescript-eslint/prefer-for-of': 'error',
       '@typescript-eslint/prefer-function-type': 'error',
-      '@typescript-eslint/prefer-namespace-keyword': 'error',
       '@typescript-eslint/quotes': [
          'error',
          'single'

--- a/ts.js
+++ b/ts.js
@@ -95,6 +95,8 @@
             'allowShortCircuit': true
          }
       ],
+      'no-empty-function': 'off',
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'error',
       'no-use-before-define': 'off',
       '@typescript-eslint/no-use-before-define': 'error',


### PR DESCRIPTION
Our ts config was in need of some cleanup. I enabled `eslint:recommended` on our ts config, which bought us a lot of the rules we had in there for free. Then, for each rule, I went through and:
- If it made sense for that rule to be moved to common-rules, I moved it there.
- If it made sense for that rule to be moved to es6, I moved it there
- If that rule was already enabled via `eslint:recommended` or `@typescript-eslint/recommended` or one of the rulesets we inherit (common-rules, es6-rules), or if it matched its default setting, I deleted it.

common-rules got a few new rules: no-invalid-this, no-caller, id-match, id-denylist, guard-for-in, spaced-comment, no-underscore-dangle. Open to pushback on these, but they seemed sensible and we were already using them in TS.

Additionally I changed TS in a couple ways:
- 'linebreak-style': 'off' removed
- array-type is now 'array'