### PR TITLE
Rule refinements

### DIFF
--- a/common-rules.js
+++ b/common-rules.js
@@ -84,7 +84,18 @@
       'no-array-constructor': error(),
       'no-bitwise': error(),
       'no-lonely-if': error(),
-      'no-mixed-operators': error(),
+      "no-mixed-operators": [
+         "error",
+         {
+            "groups": [
+               ["&", "|", "^", "~", "<<", ">>", ">>>"],
+               ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+               ["&&", "||"],
+               ["in", "instanceof"]
+            ],
+            "allowSamePrecedence": true
+         }
+      ],
       'no-multi-assign': error(),
       'no-multiple-empty-lines': error(),
       'no-nested-ternary': error(),

--- a/common-rules.js
+++ b/common-rules.js
@@ -5,10 +5,6 @@
 
    module.exports = {
       'no-console': error(),
-      'no-extra-parens': error('all', {
-         nestedBinaryExpressions: false,
-         ignoreJSX: 'all'
-      }),
       'no-unsafe-negation': error(),
       'curly': error('all'),
       'dot-location': error('property'),

--- a/common-rules.js
+++ b/common-rules.js
@@ -158,7 +158,6 @@
                '/'
             ]
          }
-      ],
-      'no-underscore-dangle': 'error',
+      ]
    };
 }());

--- a/common-rules.js
+++ b/common-rules.js
@@ -13,7 +13,6 @@
       'indent': error(3, {
          'SwitchCase': 1
       }),
-      'linebreak-style': error('windows'),
       'quotes': error('single', {
          avoidEscape: true
       }),

--- a/ts.js
+++ b/ts.js
@@ -80,15 +80,6 @@
             'hoist': 'all'
          }
       ],
-      'no-extra-parens': 'off',
-      '@typescript-eslint/no-extra-parens': [
-         'error',
-         'all',
-         {
-            'nestedBinaryExpressions': false,
-            'ignoreJSX': 'all' 
-         }
-      ],
       '@typescript-eslint/no-unused-expressions': [
          'error',
          {

--- a/ts.js
+++ b/ts.js
@@ -132,7 +132,8 @@
             "allowConciseArrowFunctionExpressionsStartingWithVoid": false
          }
       ],
-      '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}]
+      '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}],
+      '@typescript-eslint/no-misused-promises': ['error', {'checksConditionals': true, 'checksVoidReturn': false}]
    };
 
    module.exports = {


### PR DESCRIPTION
Open for debate on all changes. Here's my logic for each:

no-misused-promises change:
Currently we're inheriting the defaults from `@typescript-eslint/recommended-requiring-type-checking`. This changes it so that `checksConditionals` is true but `checksVoidReturn` is false. I think this is the appropriate config - in my experience, using a promise as a conditional is almost always a mistake (e.g. you forgot to await), but using async funcs where void funcs are expected is something we intentionally do all over the place, e.g. in event handlers

removed no-extra-parens:
In practice, I think this rule a) conflicts with other rules that require you to clarify intent with "extra" parens, and b) is too restrictive on freedom to clarify code. I think the intent is that if you need extra parens maybe your line of code is too long, but in practice I think there's a lot of gray room and we should just allow it.

no-mixed-operators change:
I changed the "groups" from the default so that now math allows mixed operators (e.g. `+` and `*`). Maybe it's just cuz I'm a "math guy", but I don't think mixing `+` and `*` is unclear.

removed linebreak-style:
I have this disabled in both projects where I "own" the linting. In practice, this setting seems to be pretty useless, since your line breaks are usually controlled by your git settings, both where you validate the code (build servers) and where you develop the code locally, so this setting tends to just be a reflection of how different systems have git configured rather than a meaningful linting rule. This rule has particularly been a headache when you have both mac and windows build servers, and I've never gotten this rule to work for both

remove no-underscore-dangle:
Meh. In the last PR I moved this from the TS rules to the common rules, but I think we should just remove it. It's unnecessarily opinionated IMO.