### PR TITLE
Fix ts magic numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-techsmith",
-  "version": "2.5.0",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-techsmith",
-      "version": "2.5.0",
+      "version": "3.0.2",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.32.0",
         "@typescript-eslint/parser": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techsmith",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/ts.js
+++ b/ts.js
@@ -139,6 +139,15 @@
       'no-constant-condition': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'error',
       'no-useless-constructor': 'off',
+      'no-magic-numbers': 'off',
+      '@typescript-eslint/no-magic-numbers': ['error', {
+         ignoreArrayIndexes: true,
+         ignore: [-1, 0, 1, 2, 10, 60, 100, 1000],
+         ignoreEnums: true,
+         ignoreNumericLiteralTypes: true,
+         ignoreReadonlyClassProperties: true,
+         ignoreTypeIndexes: true
+      }],
       '@typescript-eslint/no-useless-constructor': 'error',
       '@typescript-eslint/non-nullable-type-assertion-style': 'error',
       '@typescript-eslint/prefer-for-of': 'error',


### PR DESCRIPTION
Disables `no-magic-numbers` for TS and enables `@typescript-eslint/no-magic-numbers` instead with some nice TS-specific options https://typescript-eslint.io/rules/no-magic-numbers/