### PR TITLE
Switch some more ts rules to ts-specific versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techsmith",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/ts.js
+++ b/ts.js
@@ -116,14 +116,14 @@
       '@typescript-eslint/type-annotation-spacing': 'error',
       '@typescript-eslint/unified-signatures': 'error',
       'consistent-return': 'off',
-      "@typescript-eslint/explicit-function-return-type": [
-         "error",
+      '@typescript-eslint/explicit-function-return-type': [
+         'error',
          {
-            "allowExpressions": true,
-            "allowTypedFunctionExpressions": true,
-            "allowHigherOrderFunctions": false,
-            "allowDirectConstAssertionInArrowFunctions": false,
-            "allowConciseArrowFunctionExpressionsStartingWithVoid": false
+            'allowExpressions': true,
+            'allowTypedFunctionExpressions': true,
+            'allowHigherOrderFunctions': false,
+            'allowDirectConstAssertionInArrowFunctions': false,
+            'allowConciseArrowFunctionExpressionsStartingWithVoid': false
          }
       ],
       '@typescript-eslint/no-inferrable-types': ['error', {'ignoreParameters': true}],
@@ -158,7 +158,21 @@
       '@typescript-eslint/prefer-reduce-type-parameter': 'error',
       '@typescript-eslint/prefer-string-starts-ends-with': 'error',
       '@typescript-eslint/prefer-ts-expect-error': 'error',
-      '@typescript-eslint/no-non-null-assertion': 'off'
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      'brace-style': 'off',
+      '@typescript-eslint/brace-style': 'error',
+      'comma-spacing': 'off',
+      '@typescript-eslint/comma-spacing': 'error',
+      'func-call-spacing': 'off',
+      '@typescript-eslint/func-call-spacing': 'error',
+      'keyword-spacing': 'off',
+      '@typescript-eslint/keyword-spacing': 'error',
+      'object-curly-spacing': 'off',
+      '@typescript-eslint/object-curly-spacing': 'error',
+      'space-before-blocks': 'off',
+      '@typescript-eslint/space-before-blocks': 'error',
+      'space-infix-ops': 'off',
+      '@typescript-eslint/space-infix-ops': 'error'
    };
 
    module.exports = {


### PR DESCRIPTION
I noticed that there was some `nit - whitespace` comments in [this PR](https://github.com/TechSmith/Olympus/pull/102#discussion_r1020470385) so I decided to go through eslint's typescript formatting rules with a fine-tooth comb to see if we can automate some of that - turns out we can.

I went through all of the "formatting rules" listed [here](https://typescript-eslint.io/rules/) and for the ones that we were already using in base JS (i.e. in common-rules), I turned on TS-specific versions, and tested in Audiate.

In practice, this pretty much just means a little whitespace churn around type definitions, here's what it looks like in Audiate: https://github.com/TechSmith/audiate/pull/2302/files