### PR TITLE
Ts no undef off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techsmith",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",

--- a/ts.js
+++ b/ts.js
@@ -172,7 +172,8 @@
       'space-before-blocks': 'off',
       '@typescript-eslint/space-before-blocks': 'error',
       'space-infix-ops': 'off',
-      '@typescript-eslint/space-infix-ops': 'error'
+      '@typescript-eslint/space-infix-ops': 'error',
+      'no-undef': 'off'
    };
 
    module.exports = {


### PR DESCRIPTION
`no-undef` is not recommended for linting TS, since TS itself does it much better. Joe ran into a case where TS could correctly find a global but eslint couldn't, which caused him to stumble on that recommendation.

https://typescript-eslint.io/linting/troubleshooting/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors